### PR TITLE
chore: add VM testing matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
             cloud-image-utils \
             qemu \
             qemu-efi \
-            qemu-system-390x
+            qemu-system-s390x
 
       - name: Run vm_test.sh
         run: "./ci/scripts/vm_test.sh '${{ matrix.architecture }}' '${{ matrix.kernel }}'"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,9 +50,9 @@ jobs:
     strategy:
       matrix:
         kernel:
-          - "5.8.5"   # a 5.8 kernel, lowest supported minor release
+          - "5.8.5" # a 5.8 kernel, lowest supported minor release
           - "5.11.22" # common kernel on cloud K8s
-          - "5.16.0"  # newish kernel
+          - "5.16.0" # newish kernel
         architecture:
           - amd64 # little endian
           - s390x # big endian

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
             cloud-image-utils \
             qemu \
             qemu-efi \
-            qemu-system-s390x
+            qemu-system
 
       - name: Run vm_test.sh
         run: "./ci/scripts/vm_test.sh '${{ matrix.architecture }}' '${{ matrix.kernel }}'"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,80 @@
+name: test
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "*"
+
+  pull_request:
+    branches:
+      - main
+
+  workflow_dispatch:
+
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  issues: none
+  packages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
+jobs:
+  test-standard:
+    name: test/standard
+    runs-on: ubuntu-20.04 # amd64, little endian
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "^1.16.12"
+
+      - name: Install gotestsum
+        run: go get gotest.tools/gotestsum
+
+      - name: Run tests
+        run: make test/go
+
+  test-vm:
+    name: test/vm
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        kernel:
+          - "5.15.7"
+          - "5.11.22"
+          - "5.8.18"
+        architecture:
+          - amd64 # little endian
+          - s390x # big endian
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "^1.16.12"
+
+      - name: Install dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: |
+          sudo apt update
+          sudo apt install -y \
+            cloud-image-utils \
+            qemu \
+            qemu-efi \
+            qemu-system-390x
+
+      - name: Run vm_test.sh
+        run: "./ci/scripts/vm_test.sh '${{ matrix.architecture }}' '${{ matrix.kernel }}'"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,9 +50,9 @@ jobs:
     strategy:
       matrix:
         kernel:
-          - "5.15.7"
-          - "5.11.22"
-          - "5.8.18"
+          - "5.8.5"   # a 5.8 kernel, lowest supported minor release
+          - "5.11.22" # common kernel on cloud K8s
+          - "5.16.0"  # newish kernel
         architecture:
           - amd64 # little endian
           - s390x # big endian

--- a/Makefile
+++ b/Makefile
@@ -63,3 +63,10 @@ lint/c: ci/.clang-image
 .PHONY: lint/shellcheck
 lint/shellcheck:
 	./ci/scripts/shellcheck.sh
+
+.PHONY: test
+test: test/go
+
+.PHONY: test/go
+test/go:
+	./ci/scripts/test_go.sh

--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ You will need the following:
 
 - Docker (the Makefile runs clang within a Docker container for reproducibility)
 - `golangci-lint`
+- `gotestsum`
 - `prettier`
 - `shellcheck`
 

--- a/ci/scripts/lib.sh
+++ b/ci/scripts/lib.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# This file contains bash helper functions intended for use by other script
+# files in this directory.
+
+set -euxo pipefail
+
+echoerr() {
+  echo "$@" >&2
+}
+
+fatal() {
+  echoerr "$@"
+  exit 1
+}
+
+download_file() {
+  url="$1"
+  dest="$2"
+  temp_dest="$dest.tmp$RANDOM"
+
+  echoerr "+ Downloading $dest"
+  rc=0
+  curl --fail --location "$url" --output "$temp_dest" || rc=$?
+  if [[ $rc != 0 ]]; then
+    rm -rf "$temp_dest"
+    echoerr "Failed to download file using curl"
+    exit $rc
+  fi
+  mv "$temp_dest" "$dest"
+}
+
+download_file_if_exists() {
+  url="$1"
+  dest="$2"
+  if [ ! -e "$dest" ]; then
+    download_file "$url" "$dest"
+  fi
+}
+
+validate_checksum() {
+  checksum_file="$(realpath "$1")"
+  target_dir="$(dirname "$2")"
+  target_file="$(basename "$2")"
+
+  echoerr "+ Validating SHA256 checksum of $target_file"
+  pushd "$target_dir"
+    rc=0
+    grep "$target_file" "$checksum_file" | sha256sum --check || rc=$?
+    if [[ $rc != 0 ]]; then
+      echoerr "Could not validate SHA256 sum of file '$target_file'"
+      rm -rf "$2"
+      exit $rc
+    fi
+  popd
+}

--- a/ci/scripts/lib.sh
+++ b/ci/scripts/lib.sh
@@ -3,7 +3,7 @@
 # This file contains bash helper functions intended for use by other script
 # files in this directory.
 
-set -euxo pipefail
+set -euo pipefail
 
 echoerr() {
   echo "$@" >&2

--- a/ci/scripts/shellcheck.sh
+++ b/ci/scripts/shellcheck.sh
@@ -7,4 +7,4 @@ cd "$(dirname "$0")"
 cd "$(git rev-parse --show-toplevel)"
 
 shopt -s globstar nullglob
-shellcheck ./**/*.sh
+shellcheck -e SC1091 ./**/*.sh

--- a/ci/scripts/test_go.sh
+++ b/ci/scripts/test_go.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+cd "$(dirname "$0")"
+cd "$(git rev-parse --show-toplevel)"
+
+export FORCE_COLOR=true
+gotestsum \
+  --debug \
+  --hide-summary=skipped \
+  --packages="." \
+  -- \
+  -v

--- a/ci/scripts/vm_test.sh
+++ b/ci/scripts/vm_test.sh
@@ -1,0 +1,364 @@
+#!/bin/bash
+
+# This script creates a VM with the given architecture and an Ubuntu 20.04
+# image, sets it up using cloud-init, installs the given kernel, reboots, and
+# run tests using a pre-compiled Go test binary.
+#
+# Only architectures supported by Golang are supported. You can see a full list
+# here:
+# https://gist.github.com/asukakenji/f15ba7e588ac42795f421b48b8aede63#goarch-values
+#
+# Only architectures supported by Ubuntu 20.04 are supported. You can see a full
+# list here:
+# https://cloud-images.ubuntu.com/focal/current/
+#
+# Only kernel versions available in Ubuntu's mainline kernel repository are
+# supported. You can see a full list here:
+# https://kernel.ubuntu.com/~kernel-ppa/mainline/?C=N;O=D
+#
+# Usage:
+# $ vm_test.sh arm64 5.11.8  # uses qemu-system-aarch64
+# $ vm_test.sh amd64 5.16.0  # uses qemu-system-x86_64
+#
+# Depends on:
+# - sudo (and sudoer privileges)
+# - go
+# - curl
+# - sha256sum
+# - qemu-nbd
+# - cloud-image-utils (for cloud-init)
+# - qemu for the corresponding arch
+# - qemu-efi when arch is arm
+# - ssh, scp
+
+set -euo pipefail
+
+# Don't write `set -x` output to stderr, write it to a temp file instead.
+xtrace="$(mktemp)"
+exec 24>"$xtrace"
+BASH_XTRACEFD=24
+set -x
+
+cd "$(dirname "$0")"
+source ./lib.sh
+
+arch="$1"
+kernel="${2%.0}"
+
+kernel_url="https://kernel.ubuntu.com/~kernel-ppa/mainline/v$kernel/$arch"
+kernel_sum_file="kernel.CHECKSUMS"
+kernel_sum_url="$kernel_url/CHECKSUMS"
+
+image_file="focal-server-cloudimg-$arch.img"
+image_url="https://cloud-images.ubuntu.com/focal/current/$image_file"
+image_sum_file="SHA256SUMS"
+image_sum_url="https://cloud-images.ubuntu.com/focal/current/$image_sum_file"
+
+repo_root="$(git rev-parse --show-toplevel)"
+
+# Create test persistence directory. This should only store things that can be
+# cached/used across multiple tests.
+persistent_dir="$(realpath ../.test)"
+mkdir -p "$persistent_dir"
+
+# Create temporary test directory. This should only store files used by the
+# single test run.
+temp_dir="$(mktemp -d --suffix=.exectrace_test)"
+cd "$temp_dir"
+echo "Using temporary directory '$temp_dir'"
+
+# Remap the requested architecture to the qemu equivalent.
+vm_arch="$arch"
+case "$vm_arch" in
+  arm64)
+    vm_arch="aarch64"
+    ;;
+  amd64)
+    vm_arch="x86_64"
+    ;;
+esac
+
+# We have to put the image in the persistent dir to avoid filling tmp.
+hostname="exectrace-$arch-${kernel//./-}-$RANDOM"
+volume_file="$persistent_dir/$hostname.$image_file.qcow2"
+pid=""
+
+# Defer cleanup.
+cleanup() {
+  rc=$?
+  if [[ $rc != 0 ]]; then
+      echoerr
+      echoerr "The test process failed. Please read the above logs for more"
+      echoerr "information."
+      echoerr
+      if [[ "${CI:-}" == "" ]]; then
+        echoerr "Additional information can be found in '$xtrace'."
+      else
+        echo "::group::Bash xtrace (set -x) output:"
+        cat "$xtrace"
+        echo "::endgroup"
+      fi
+      echoerr
+      echoerr "Exit code was $rc."
+      echoerr
+  fi
+
+  if [ "$pid" != "" ]; then
+    echoerr "+ Cleanup: kill qemu"
+    sudo kill -9 "$pid"
+  fi
+  if [ -e "$volume_file" ]; then
+    echoerr "+ Cleanup: delete volume file"
+    sudo rm -rf "$volume_file"
+  fi
+
+  echoerr "+ Cleanup: delete temp dir"
+  sudo rm -rf "$temp_dir"
+
+  exit $rc
+}
+trap 'cleanup' EXIT
+
+# Compile a test binary for the target architecture.
+test_binary="exectrace.test"
+pushd "$repo_root"
+  GOARCH="$arch" go test -c -o "$temp_dir/$test_binary" ./
+popd
+if [ ! -e "$test_binary" ]; then
+  fatal "The go toolchain did not produce a binary at '$test_binary'"
+fi
+
+# Determine the kernel package names to use from the Ubuntu mainline webserver.
+echo "+ Determine kernel package names"
+download_file "$kernel_sum_url" "$kernel_sum_file"
+kernel_image_pkg="$(grep -ioPm 1 "linux-image-(unsigned-)?.*generic.*\\.deb" "$kernel_sum_file")"
+kernel_image_pkg_name="$(echo "$kernel_image_pkg" | grep -io "[0-9].*-generic")"
+kernel_module_pkg="$(grep -iom 1 "linux-modules.*generic.*" "$kernel_sum_file")"
+if [[ "$kernel_image_pkg" == "" ]] || [[ "$kernel_module_pkg" == "" ]]; then
+  fatal "Could not determine the kernel image or module packages."
+fi
+echoerr "Using kernel image package '$kernel_image_pkg' ($kernel_image_pkg_name) and '$kernel_module_pkg'."
+
+# Download the packages so we can cache them.
+kernel_image_path="$persistent_dir/$kernel_image_pkg"
+download_file_if_exists "$kernel_url/$kernel_image_pkg" "$kernel_image_path"
+validate_checksum "$kernel_sum_file" "$kernel_image_path"
+kernel_module_path="$persistent_dir/$kernel_module_pkg"
+download_file_if_exists "$kernel_url/$kernel_module_pkg" "$kernel_module_path"
+validate_checksum "$kernel_sum_file" "$kernel_module_path"
+
+# Download the Ubuntu image file.
+image_path="$persistent_dir/$image_file"
+download_file "$image_sum_url" "$image_sum_file"
+download_file_if_exists "$image_url" "$image_path"
+validate_checksum "$image_sum_file" "$image_path"
+
+# Copy the image to make a fresh volume. We expand the image to increase from 2G
+# to a usable size.
+cp "$image_path" "$volume_file"
+qemu-img resize "$volume_file" +10G
+
+# Generate an SSH key if one doesn't exist.
+ssh_key_path="$persistent_dir/id_ed25519"
+if [ ! -e "$ssh_key_path" ]; then
+  ssh-keygen -t ed25519 -f "$ssh_key_path" -C "exectrace+test@coder.com" -q -N ""
+fi
+
+# Create cloud-init config.
+username="root"
+cat <<EOF > cloud_init.cfg
+#cloud-config
+hostname: "$hostname"
+fqdn: "$hostname.exectrace.cdr.dev"
+manage_etc_hosts: true
+ssh_pwauth: false
+users:
+  - name: "$username"
+    shell: /bin/bash
+    ssh-authorized-keys:
+      - "$(cat "$ssh_key_path.pub")"
+
+EOF
+
+# Compile cloud-init config into a seed volume.
+cloudinit_seed_file="$(mktemp --suffix=.exectrace.cloud_init_seed.img)"
+cloud-localds -v --disk-format raw -f vfat "$cloudinit_seed_file" cloud_init.cfg
+
+# Prepare arguments for qemu.
+pid_file="./qemu.pid"
+host="$username@localhost"
+port="2222"
+monitor_socket="$temp_dir/qemu.sock"
+
+qemu_args=(
+  -nographic
+  -device "virtio-net-pci,netdev=net0"
+  -netdev "user,id=net0,hostfwd=tcp::$port-:22"
+  -m 2048
+  -boot "order=c,menu=off"
+  -hda "$volume_file"
+  -hdb "$cloudinit_seed_file"
+  -pidfile "$pid_file"
+  -monitor "unix:$monitor_socket,server,nowait"
+)
+if [[ "$(uname -m)" == "$arch" ]] || [[ "$(uname -m)" == "$vm_arch" ]]; then
+  qemu_args+=(
+    --enable-kvm
+    -cpu host
+  )
+else
+  if [[ "$arch" == *arm* ]]; then
+    qemu_args+=(
+      -cpu cortex-a57
+      -machine virt
+    )
+  fi
+fi
+
+# Arm requires EFI.
+if [[ "$arch" == *arm* ]]; then
+  dd if=/dev/zero of=flash0.img bs=1M count=64
+  dd if=/usr/share/qemu-efi/QEMU_EFI.fd of=flash0.img conv=notrunc
+  dd if=/dev/zero of=flash1.img bs=1M count=64
+  qemu_args+=(
+    -pflash flash0.img
+    -pflash flash1.img
+  )
+fi
+
+# Start qemu in the background with output being redirected to a file.
+log_file="$(mktemp --tmpdir tmp.exectrace-qemu.XXXXX.log)"
+echoerr "Starting qemu with log file '$log_file'"
+echoerr "QEMU monitor will be available at '$monitor_socket'"
+#nohup sudo "qemu-system-$vm_arch" "${qemu_args[@]}" &>"$log_file" & disown
+sudo "qemu-system-$vm_arch" "${qemu_args[@]}"
+sleep 5
+
+dump_log() {
+  echoerr "$1"
+  echoerr "The qemu log file is as follows:"
+  echoerr
+  cat "$log_file"
+  echoerr
+  echoerr "$1"
+  echoerr "The qemu log file is pritned above"
+}
+
+pid="$(sudo cat "$pid_file")"
+if [ "$pid" == "" ]; then
+  fatal "qemu pid file was empty"
+fi
+
+ensure_qemu_running() {
+  if [ ! -e "/proc/$pid/status" ]; then
+    dump_log "The VM process no longer exists (most likely a crash)"
+    exit 1
+  fi
+}
+ensure_qemu_running
+
+xssh() {
+  # The ConnectTimeout is cranked up because it can take a very long time to
+  # connect to emulated VMs.
+  ssh \
+    -o StrictHostKeyChecking=no \
+    -o UserKnownHostsFile=/dev/null \
+    -o ConnectTimeout=30 \
+    -q \
+    -i "$ssh_key_path" \
+    -p "$port" \
+    "$host" "$@"
+}
+xscp() {
+  scp \
+    -o StrictHostKeyChecking=no \
+    -o UserKnownHostsFile=/dev/null \
+    -o ConnectTimeout=30 \
+    -q \
+    -i "$ssh_key_path" \
+    -P "$port" \
+    "$@"
+}
+
+wait_ssh() {
+  echoerr "+ Waiting for the VM to start for up to 10 minutes"
+  wait_ssh_end="$(date --date 'now + 10 minutes' '+%s')"
+  while true; do
+    if [[ "$(date '+%s')" > "$wait_ssh_end" ]]; then
+      dump_log "The VM did not become available within 10 minutes"
+      exit 1
+    fi
+
+    ensure_qemu_running
+    if xssh exit 0; then
+      echoerr "+ Successfully connected"
+      break
+    fi
+
+    sleep 1
+  done
+}
+
+# Install the target kernel and reboot.
+wait_ssh
+xscp "$kernel_image_path" "$kernel_module_path" "$host:~/"
+xssh /bin/bash <<EOF
+set -euxo pipefail
+export DEBIAN_FRONTEND=noninteractive
+
+echo "+ Install the target kernel and modules"
+apt update
+apt install -y "./$kernel_image_pkg" "./$kernel_module_pkg"
+rm -f "./$kernel_image_pkg" "./$kernel_module_pkg"
+
+# s390x uses zipl to do the boot process. The most recently installed kernel is
+# used for booting.
+if command -v zipl; then
+  echo "+ Detected non-grub bootloader, rebooting"
+  reboot
+  exit 0
+fi
+
+echo "+ Prepare for reboot"
+# Taken from https://askubuntu.com/a/1121712
+set +e
+menu_entries="\$(awk -F\' '\$1=="menuentry " || \$1=="submenu " {print i++ "\t" \$2}; /\tmenuentry / {print i-1">"j++ "\t" \$2};' /boot/grub/grub.cfg)"
+menu_entry="\$(echo "\$menu_entries" | grep -iF "$kernel_image_pkg_name" | grep -iv recovery | head -n1 | awk '{ print \$1 }')"
+if [[ "\$menu_entry" == "" ]]; then
+  echo "Could not determine grub entry for newly installed kernel:"
+  echo "\$menu_entries"
+  exit 1
+fi
+echo "Found grub entry \$menu_entry"
+set -e
+grub-reboot "\$menu_entry"
+
+echo "+ Reboot"
+reboot
+
+EOF
+
+# Copy the test binary to the VM.
+sleep 30
+wait_ssh
+xscp "$test_binary" "$host:~/$test_binary"
+
+echoerr "+ Running test suite"
+rc=0
+xssh /bin/bash <<EOF || rc=$?
+set -euxo pipefail
+
+if [[ "\$(uname -r)" != *"$kernel_image_pkg_name"* ]]; then
+  echo "Booted into unwanted kernel:"
+  uname -a
+  exit 1
+fi
+
+# shellcheck disable=SC2088 # intentionally don't want ~ to expand by using "
+"~/$test_binary" -test.v -test.timeout=10m
+EOF
+
+xssh poweroff || true
+sleep 15
+
+exit $rc

--- a/ci/scripts/vm_test.sh
+++ b/ci/scripts/vm_test.sh
@@ -318,6 +318,11 @@ xssh /bin/bash <<EOF
 set -euxo pipefail
 export DEBIAN_FRONTEND=noninteractive
 
+do_reboot() {
+  nohup /bin/sh -c "sleep 5 && reboot" & disown
+  exit 0
+}
+
 echo "+ Install the target kernel and modules"
 apt update
 apt install -y "./$kernel_image_pkg" "./$kernel_module_pkg"
@@ -327,7 +332,7 @@ rm -f "./$kernel_image_pkg" "./$kernel_module_pkg"
 # used for booting.
 if command -v zipl; then
   echo "+ Detected non-grub bootloader, rebooting"
-  reboot
+  do_reboot
   exit 0
 fi
 
@@ -346,7 +351,7 @@ set -e
 grub-reboot "\$menu_entry"
 
 echo "+ Reboot"
-reboot
+do_reboot
 
 EOF
 

--- a/ci/scripts/vm_test.sh
+++ b/ci/scripts/vm_test.sh
@@ -253,9 +253,10 @@ dump_log() {
   echoerr "The qemu log file is pritned above"
 }
 
-pid="$(sudo cat "$pid_file")"
+pid="$(sudo cat "$pid_file" || true)"
 if [ "$pid" == "" ]; then
-  fatal "qemu pid file was empty"
+  dump_log "qemu pid file was missing or empty"
+  exit 1
 fi
 
 ensure_qemu_running() {

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -1,0 +1,7 @@
+package exectrace
+
+import "testing"
+
+func Test_x(_ *testing.T) {
+	println("working!")
+}


### PR DESCRIPTION
- Add testing script `vm_test.sh <arch> <kernel>` which creates an Ubuntu 20.04 on the requested arch, installs the requested kernel, reboots, and runs go tests
- Add github workflow for running `vm_test.sh` with a matrix for both little and big endian CPUs and multiple supported kernel versions